### PR TITLE
Same as State, create a new view for City objects that handles all de…

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -5,3 +5,4 @@ app_views = Blueprint('app_views', __name__, url_prefix='/api/v1')
 
 from api.v1.views.index import *
 from api.v1.views.states import *
+from api.v1.views.cities import *

--- a/api/v1/views/cities.py
+++ b/api/v1/views/cities.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+""" View for City objects that handles default API actions """
+from api.v1.views import app_views
+from flask import jsonify, abort, make_response, request
+from models import storage
+from models.state import State
+from models.city import City
+
+
+@app_views.route('/states/<state_id>/cities', methods=['GET'],
+                 strict_slashes=False)
+def cities(state_id):
+    """ Retrieves the list of all City objects """
+    state = storage.get("State", state_id)
+    if not state:
+        abort(404)
+    return jsonify([city.to_dict() for city in state.cities])
+
+
+@app_views.route('/cities/<city_id>', methods=['GET'], strict_slashes=False)
+def r_city_id(city_id):
+    """ Retrieves a City object """
+    city = storage.get("City", city_id)
+    if not city:
+        abort(404)
+    return jsonify(city.to_dict())
+
+
+@app_views.route('/cities/<city_id>', methods=['DELETE'],
+                 strict_slashes=False)
+def del_city(city_id):
+    """ Deletes a City object """
+    city = storage.get("City", city_id)
+    if not city:
+        abort(404)
+    city.delete()
+    storage.save()
+    return make_response(jsonify({}), 200)
+
+
+@app_views.route('/states/<state_id>/cities', methods=['POST'],
+                 strict_slashes=False)
+def post_city(state_id):
+    """ Creates a City object """
+    state = storage.get("State", state_id)
+    if not state:
+        abort(404)
+    new_city = request.get_json()
+    if not new_city:
+        abort(400, "Not a JSON")
+    if "name" not in new_city:
+        abort(400, "Missing name")
+    city = City(**new_city)
+    setattr(city, 'state_id', state_id)
+    storage.new(city)
+    storage.save()
+    return make_response(jsonify(city.to_dict()), 201)
+
+
+@app_views.route('/cities/<city_id>', methods=['PUT'],
+                 strict_slashes=False)
+def put_city(city_id):
+    """ Updates a City object """
+    city = storage.get("City", city_id)
+    if not city:
+        abort(404)
+
+    body_request = request.get_json()
+    if not body_request:
+        abort(400, "Not a JSON")
+
+    for k, v in body_request.items():
+        if k not in ['id', 'state_id', 'created_at', 'updated_at']:
+            setattr(city, k, v)
+
+    storage.save()
+    return make_response(jsonify(city.to_dict()), 200)


### PR DESCRIPTION
…fault RESTFul API actions

In the file api/v1/views/cities.py
You must use to_dict() to serialize an object into valid JSON Update api/v1/views/__init__.py to import this new file Retrieves the list of all City objects of a State: GET /api/v1/states/<state_id>/cities

If the state_id is not linked to any State object, raise a 404 error
Retrieves a City object. : GET /api/v1/cities/<city_id>

If the city_id is not linked to any City object, raise a 404 error
Deletes a City object: DELETE /api/v1/cities/<city_id>

If the city_id is not linked to any City object, raise a 404 error Returns an empty dictionary with the status code 200 Creates a City: POST /api/v1/states/<state_id>/cities

You must use request.get_json from Flask to transform the HTTP body request to a dictionary If the state_id is not linked to any State object, raise a 404 error If the HTTP body request is not a valid JSON, raise a 400 error with the message Not a JSON If the dictionary doesn’t contain the key name, raise a 400 error with the message Missing name Returns the new City with the status code 201
Updates a City object: PUT /api/v1/cities/<city_id>

If the city_id is not linked to any City object, raise a 404 error You must use request.get_json from Flask to transform the HTTP body request to a dictionary If the HTTP request body is not valid JSON, raise a 400 error with the message Not a JSON Update the City object with all key-value pairs of the dictionary Ignore keys: id, state_id, created_at and updated_at Returns the City object with the status code 200