### PR TITLE
Adding task 15. Search

### DIFF
--- a/api/v1/views/places.py
+++ b/api/v1/views/places.py
@@ -5,6 +5,9 @@ from flask import jsonify, abort, make_response, request
 from models import storage
 from models.city import City
 from models.place import Place
+import requests
+import json
+from os import getenv
 
 
 @app_views.route('/cities/<city_id>/places', methods=['GET'],
@@ -81,3 +84,70 @@ def put_place(place_id):
 
     storage.save()
     return make_response(jsonify(place.to_dict()), 200)
+
+
+@app_views.route('/places_search', methods=['POST'],
+                 strict_slashes=False)
+def places_search():
+    """
+    Retrieves all Place objects depending of
+    the JSON in the body of the request
+    """
+    body_r = request.get_json()
+    if body_r is None:
+        abort(400, "Not a JSON")
+
+    if not body_r or (
+            not body_r.get('states') and
+            not body_r.get('cities') and
+            not body_r.get('amenities')
+    ):
+        places = storage.all(Place)
+        return jsonify([place.to_dict() for place in places.values()])
+
+    places = []
+
+    if body_r.get('states'):
+        states = [storage.get("State", id) for id in body_r.get('states')]
+
+        for state in states:
+            for city in state.cities:
+                for place in city.places:
+                    places.append(place)
+
+    if body_r.get('cities'):
+        cities = [storage.get("City", id) for id in body_r.get('cities')]
+
+        for city in cities:
+            for place in city.places:
+                if place not in places:
+                    places.append(place)
+
+    if not places:
+        places = storage.all(Place)
+        places = [place for place in places.values()]
+
+    if body_r.get('amenities'):
+        ams = [storage.get("Amenity", id) for id in body_r.get('amenities')]
+        i = 0
+        limit = len(places)
+        HBNB_API_HOST = getenv('HBNB_API_HOST')
+        HBNB_API_PORT = getenv('HBNB_API_PORT')
+
+        port = 5000 if not HBNB_API_PORT else HBNB_API_PORT
+        first_url = "http://0.0.0.0:{}/api/v1/places/".format(port)
+        while i < limit:
+            place = places[i]
+            url = first_url + '{}/amenities'
+            req = url.format(place.id)
+            response = requests.get(req)
+            am_d = json.loads(response.text)
+            amenities = [storage.get("Amenity", o['id']) for o in am_d]
+            for amenity in ams:
+                if amenity not in amenities:
+                    places.pop(i)
+                    i -= 1
+                    limit -= 1
+                    break
+            i += 1
+    return jsonify([place.to_dict() for place in places])


### PR DESCRIPTION
For the moment, the only way to list Place objects is via GET /api/v1/cities/<city_id>/places.

Good, but not enough…

Update api/v1/views/places.py to add a new endpoint: POST /api/v1/places_search that retrieves all Place objects depending of the JSON in the body of the request.

The JSON can contain 3 optional keys:

- states: list of State ids
- cities: list of City ids
- amenities: list of Amenity ids

Search rules:

- If the HTTP request body is not valid JSON, raise a 400 error with the message Not a JSON
- If the JSON body is empty or each list of all keys are empty: retrieve all Place objects
- If states list is not empty, results should include all Place objects for each State id listed
- If cities list is not empty, results should include all Place objects for each City id listed
- Keys states and cities are inclusive. Search results should include all Place objects in storage related to each City in every State listed in states, plus every City listed individually in cities, unless that City was already included by states.

> Context:

- State A has 2 cities A1 and A2
- State B has 3 cities B1, B2 and B3
- A1 has 1 place
- A2 has 2 places
- B1 has 3 places
- B2 has 4 places
- B3 has 5 places

> Search: states = State A and cities = B2

> Result: all 4 places from the city B2 and the place from the city A1 and the 2 places of the city A2 (because they are part of State A) => 7 places returned

- If amenities list is not empty, limit search results to only Place objects having all Amenity ids listed
- The key amenities is exclusive, acting as a filter on the results generated by states and cities, or on all Place if states and cities are both empty or missing.
- Results will only include Place objects having all listed amenities. If a Place doesn’t have even one of these amenities, it won’t be retrieved.